### PR TITLE
Fix JsonbNumberFormat on getters/setters

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/AnnotationIntrospector.java
+++ b/src/main/java/org/eclipse/yasson/internal/AnnotationIntrospector.java
@@ -361,14 +361,13 @@ public class AnnotationIntrospector {
                     return new HashMap<>();
                 }
             }
-
-            //  There is no annotation on top of property, getter or setter, so check if any annotation specified on the class containing the property
-            JsonbNumberFormat classLevelNumberFormatter = findAnnotation(property.getDeclaringClassElement().getAnnotations(), JsonbNumberFormat.class);
-            if(classLevelNumberFormatter != null) {
-                result.put(AnnotationTarget.CLASS, new JsonbNumberFormatter(classLevelNumberFormatter.value(), classLevelNumberFormatter.locale()));
-            }
         } else {
             annotationFromPropertyCategorized.forEach((key, annotation) -> result.put(key, new JsonbNumberFormatter(annotation.value(), annotation.locale())));
+        }
+
+        JsonbNumberFormat classLevelNumberFormatter = findAnnotation(property.getDeclaringClassElement().getAnnotations(), JsonbNumberFormat.class);
+        if(classLevelNumberFormatter != null) {
+            result.put(AnnotationTarget.CLASS, new JsonbNumberFormatter(classLevelNumberFormatter.value(), classLevelNumberFormatter.locale()));
         }
 
         return result;

--- a/src/main/java/org/eclipse/yasson/internal/MappingContext.java
+++ b/src/main/java/org/eclipse/yasson/internal/MappingContext.java
@@ -13,7 +13,7 @@
 package org.eclipse.yasson.internal;
 
 import org.eclipse.yasson.internal.serializer.ContainerSerializerProvider;
-import org.eclipse.yasson.model.ClassCustomization;
+import org.eclipse.yasson.model.customization.ClassCustomization;
 import org.eclipse.yasson.model.ClassModel;
 import org.eclipse.yasson.model.JsonbAnnotatedElement;
 

--- a/src/main/java/org/eclipse/yasson/internal/serializer/AbstractNumberDeserializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/AbstractNumberDeserializer.java
@@ -43,7 +43,7 @@ public abstract class AbstractNumberDeserializer<T extends Number> extends Abstr
     }
 
     protected final Optional<Number> deserializeForamtted(String jsonValue, boolean integerOnly, JsonbContext jsonbContext) {
-        final JsonbNumberFormatter numberFormat = model.getCustomization().getNumberFormat();
+        final JsonbNumberFormatter numberFormat = model.getCustomization().getDeserializeNumberFormatter();
         if (numberFormat != null) {
             //TODO perf consider synchronizing on format instance or per thread cache.
             final NumberFormat format = NumberFormat.getInstance(jsonbContext.getLocale(numberFormat.getLocale()));

--- a/src/main/java/org/eclipse/yasson/internal/serializer/AbstractNumberSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/AbstractNumberSerializer.java
@@ -70,7 +70,7 @@ public abstract class AbstractNumberSerializer<T extends Number> extends Abstrac
     protected abstract void serializeNonFormatted(T obj, JsonGenerator generator);
 
     private boolean serializeFormatted(T obj, Consumer<String> formattedConsumer, JsonbContext jsonbContext) {
-        final JsonbNumberFormatter numberFormat = model.getCustomization().getNumberFormat();
+        final JsonbNumberFormatter numberFormat = model.getCustomization().getSerializeNumberFormatter();
         if (numberFormat != null) {
             //TODO perf consider synchronizing on format instance or per thread cache.
             final NumberFormat format = NumberFormat.getInstance(jsonbContext.getLocale(numberFormat.getLocale()));

--- a/src/main/java/org/eclipse/yasson/internal/serializer/AdaptedObjectSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/AdaptedObjectSerializer.java
@@ -19,7 +19,7 @@ import org.eclipse.yasson.internal.properties.MessageKeys;
 import org.eclipse.yasson.internal.properties.Messages;
 import org.eclipse.yasson.internal.unmarshaller.CurrentItem;
 import org.eclipse.yasson.model.ClassModel;
-import org.eclipse.yasson.model.Customization;
+import org.eclipse.yasson.model.customization.Customization;
 import org.eclipse.yasson.model.JsonBindingModel;
 import org.eclipse.yasson.model.JsonContext;
 import org.eclipse.yasson.model.JsonbPropertyInfo;

--- a/src/main/java/org/eclipse/yasson/internal/unmarshaller/AbstractItem.java
+++ b/src/main/java/org/eclipse/yasson/internal/unmarshaller/AbstractItem.java
@@ -15,11 +15,10 @@ package org.eclipse.yasson.internal.unmarshaller;
 import org.eclipse.yasson.internal.AbstractSerializerBuilder;
 import org.eclipse.yasson.internal.JsonbContext;
 import org.eclipse.yasson.internal.ReflectionUtils;
-import org.eclipse.yasson.model.ClassModel;
-import org.eclipse.yasson.model.ContainerCustomization;
-import org.eclipse.yasson.model.Customization;
-import org.eclipse.yasson.model.CustomizationBuilder;
-import org.eclipse.yasson.model.JsonBindingModel;
+import org.eclipse.yasson.model.*;
+import org.eclipse.yasson.model.customization.ClassCustomizationBuilder;
+import org.eclipse.yasson.model.customization.ContainerCustomization;
+import org.eclipse.yasson.model.customization.Customization;
 
 import java.lang.reflect.Type;
 
@@ -110,6 +109,6 @@ public abstract class AbstractItem<T> implements CurrentItem<T> {
             return new ContainerCustomization(classModel.getCustomization());
         }
         // TODO deal with DefaultCustomization
-        return new ContainerCustomization(new CustomizationBuilder());
+        return new ContainerCustomization(new ClassCustomizationBuilder());
     }
 }

--- a/src/main/java/org/eclipse/yasson/internal/unmarshaller/ContainerModel.java
+++ b/src/main/java/org/eclipse/yasson/internal/unmarshaller/ContainerModel.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.yasson.internal.unmarshaller;
 
-import org.eclipse.yasson.model.Customization;
+import org.eclipse.yasson.model.customization.Customization;
 import org.eclipse.yasson.model.JsonBindingModel;
 import org.eclipse.yasson.model.JsonContext;
 

--- a/src/main/java/org/eclipse/yasson/model/AnnotationTarget.java
+++ b/src/main/java/org/eclipse/yasson/model/AnnotationTarget.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2017 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *      Ehsan Zaery Moghaddam (zaerymoghaddam@gmail.com)
+ ******************************************************************************/
+
+package org.eclipse.yasson.model;
+
+/**
+ * Represents the place in which a JSON annotation is applied. Some business functionalities are different based on whether annotation (e.g.
+ * {@link javax.json.bind.annotation.JsonbTransient}, {@link org.eclipse.yasson.internal.serializer.JsonbNumberFormatter}, etc.) is being applied on
+ * getter method, setter method or directly on the property.
+ *
+ * @author Ehsan Zaery Moghaddam (zaerymoghaddam@gmail.com)
+ */
+public enum AnnotationTarget {
+    /**
+     * Indicates annotation has been applied on class level
+     */
+    CLASS,
+
+    /**
+     * Indicates annotation has been applied on property level
+     */
+    PROPERTY,
+
+    /**
+     * Indicates annotation has been applied on the getter method of the property
+     */
+    GETTER,
+
+    /**
+     * Indicates annotation has been applied on the setter method of the property
+     */
+    SETTER
+}

--- a/src/main/java/org/eclipse/yasson/model/ClassModel.java
+++ b/src/main/java/org/eclipse/yasson/model/ClassModel.java
@@ -13,6 +13,7 @@
 package org.eclipse.yasson.model;
 
 import org.eclipse.yasson.internal.naming.CaseInsensitiveStrategy;
+import org.eclipse.yasson.model.customization.ClassCustomization;
 
 import javax.json.bind.config.PropertyNamingStrategy;
 import java.util.Collections;

--- a/src/main/java/org/eclipse/yasson/model/JsonBindingModel.java
+++ b/src/main/java/org/eclipse/yasson/model/JsonBindingModel.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.yasson.model;
 
+import org.eclipse.yasson.model.customization.Customization;
+
 import java.lang.reflect.Type;
 
 /**

--- a/src/main/java/org/eclipse/yasson/model/PropertyModel.java
+++ b/src/main/java/org/eclipse/yasson/model/PropertyModel.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * A model for class property.
@@ -155,21 +156,25 @@ public class PropertyModel implements JsonBindingModel, Comparable<PropertyModel
          * If @JsonbNumberFormat is placed on getter implementation must use this format on serialization.
          * If @JsonbNumberFormat is placed on setter implementation must use this format on deserialization.
          * If @JsonbNumberFormat is placed on field implementation must use this format on serialization and deserialization.
+         *
+         * Priority from high to low is getter / settrer > field > class > package > global configuration
          */
         Map<AnnotationTarget, JsonbNumberFormatter> jsonNumberFormatCategorized = introspector.getJsonNumberFormatter(property);
-        if(jsonNumberFormatCategorized.keySet().contains(AnnotationTarget.PROPERTY)) {
+        Set<AnnotationTarget> annotationTargets = jsonNumberFormatCategorized.keySet();
+        if(annotationTargets.contains(AnnotationTarget.GETTER)){
+            builder.setSerializeNumberFormatter(jsonNumberFormatCategorized.get(AnnotationTarget.GETTER));
+        } else if(annotationTargets.contains(AnnotationTarget.PROPERTY)){
             builder.setSerializeNumberFormatter(jsonNumberFormatCategorized.get(AnnotationTarget.PROPERTY));
-            builder.setDeserializeNumberFormatter(jsonNumberFormatCategorized.get(AnnotationTarget.PROPERTY));
-        } else if(jsonNumberFormatCategorized.keySet().contains(AnnotationTarget.CLASS)) {
+        } else if(annotationTargets.contains(AnnotationTarget.CLASS)){
             builder.setSerializeNumberFormatter(jsonNumberFormatCategorized.get(AnnotationTarget.CLASS));
+        }
+
+        if(annotationTargets.contains(AnnotationTarget.SETTER)){
+            builder.setDeserializeNumberFormatter(jsonNumberFormatCategorized.get(AnnotationTarget.SETTER));
+        } else if(annotationTargets.contains(AnnotationTarget.PROPERTY)){
+            builder.setDeserializeNumberFormatter(jsonNumberFormatCategorized.get(AnnotationTarget.PROPERTY));
+        } else if(annotationTargets.contains(AnnotationTarget.CLASS)){
             builder.setDeserializeNumberFormatter(jsonNumberFormatCategorized.get(AnnotationTarget.CLASS));
-        } else {
-            if(jsonNumberFormatCategorized.keySet().contains(AnnotationTarget.GETTER)) {
-                builder.setSerializeNumberFormatter(jsonNumberFormatCategorized.get(AnnotationTarget.GETTER));
-            }
-            if(jsonNumberFormatCategorized.keySet().contains(AnnotationTarget.SETTER)) {
-                builder.setDeserializeNumberFormatter(jsonNumberFormatCategorized.get(AnnotationTarget.SETTER));
-            }
         }
     }
 

--- a/src/main/java/org/eclipse/yasson/model/customization/ClassCustomization.java
+++ b/src/main/java/org/eclipse/yasson/model/customization/ClassCustomization.java
@@ -11,7 +11,10 @@
  * Roman Grigoriadi
  ******************************************************************************/
 
-package org.eclipse.yasson.model;
+package org.eclipse.yasson.model.customization;
+
+import org.eclipse.yasson.internal.serializer.JsonbNumberFormatter;
+import org.eclipse.yasson.model.JsonbCreator;
 
 /**
  * Customization, which could be applied on a class or package level.
@@ -24,15 +27,18 @@ public class ClassCustomization extends Customization {
 
     private String[] propertyOrder;
 
+    private final JsonbNumberFormatter numberFormatter;
+
     /**
      * Copies properties from builder an creates immutable instance.
      *
      * @param builder not null
      */
-    ClassCustomization(CustomizationBuilder builder) {
+    ClassCustomization(ClassCustomizationBuilder builder) {
         super(builder);
         this.creator = builder.getCreator();
         this.propertyOrder = builder.getPropertyOrder();
+        this.numberFormatter = builder.getNumberFormatter();
     }
 
     /**
@@ -44,6 +50,7 @@ public class ClassCustomization extends Customization {
         super(other);
         this.creator = other.getCreator();
         this.propertyOrder = other.getPropertyOrder();
+        this.numberFormatter = other.getSerializeNumberFormatter();
     }
 
     /**
@@ -69,5 +76,15 @@ public class ClassCustomization extends Customization {
      */
     public void setPropertyOrder(String[] propertyOrder) {
         this.propertyOrder = propertyOrder;
+    }
+
+    @Override
+    public JsonbNumberFormatter getSerializeNumberFormatter() {
+        return numberFormatter;
+    }
+
+    @Override
+    public JsonbNumberFormatter getDeserializeNumberFormatter() {
+        return numberFormatter;
     }
 }

--- a/src/main/java/org/eclipse/yasson/model/customization/ClassCustomizationBuilder.java
+++ b/src/main/java/org/eclipse/yasson/model/customization/ClassCustomizationBuilder.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2017 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *      Ehsan Zaery Moghaddam (zaerymoghaddam@gmail.com)
+ ******************************************************************************/
+package org.eclipse.yasson.model.customization;
+
+import org.eclipse.yasson.internal.serializer.JsonbNumberFormatter;
+
+/**
+ * The customization builder that would be used to build an instance of {@link ClassCustomization} to ensure its immutability.
+ *
+ * @author Ehsan Zaery Moghaddam (zaerymoghaddam@gmail.com)
+ */
+public class ClassCustomizationBuilder extends CustomizationBuilder {
+
+    /**
+     * The class level number formatter that would be used by default for all number properties that don't have a dedicated number formatter
+     * annotation.
+     */
+    private JsonbNumberFormatter numberFormatter;
+
+    /**
+     * Creates a customization for class properties.
+     *
+     * @return A new instance of {@link PropertyCustomization}
+     */
+    public ClassCustomization buildClassCustomization() {
+        return new ClassCustomization(this);
+    }
+
+    /**
+     * Returns the default number formatter instance that would be used for all number properties that don't have a dedicated number formatter.
+     *
+     * @return the default number formatter instance that would be used for all number properties that don't have a dedicated number formatter
+     */
+    public JsonbNumberFormatter getNumberFormatter() {
+        return numberFormatter;
+    }
+
+    /**
+     * Sets the default number formatter instance that would be used for all number properties that don't have a dedicated number formatter.
+     *
+     * @param numberFormatter the default number formatter instance that would be used for all number properties that don't have a dedicated number
+     *                        formatter.
+     */
+    public void setNumberFormatter(JsonbNumberFormatter numberFormatter) {
+        this.numberFormatter = numberFormatter;
+    }
+}

--- a/src/main/java/org/eclipse/yasson/model/customization/ContainerCustomization.java
+++ b/src/main/java/org/eclipse/yasson/model/customization/ContainerCustomization.java
@@ -10,7 +10,7 @@
  * Contributors:
  * Roman Grigoriadi
  ******************************************************************************/
-package org.eclipse.yasson.model;
+package org.eclipse.yasson.model.customization;
 
 /**
  * Customization for container like types (Maps, Collections, Arrays).
@@ -24,7 +24,7 @@ public class ContainerCustomization extends ClassCustomization {
      *
      * @param builder Builver to initialize from.
      */
-    public ContainerCustomization(CustomizationBuilder builder) {
+    public ContainerCustomization(ClassCustomizationBuilder builder) {
         super(builder);
     }
 

--- a/src/main/java/org/eclipse/yasson/model/customization/Customization.java
+++ b/src/main/java/org/eclipse/yasson/model/customization/Customization.java
@@ -10,7 +10,7 @@
  * Contributors:
  * Roman Grigoriadi
  ******************************************************************************/
-package org.eclipse.yasson.model;
+package org.eclipse.yasson.model.customization;
 
 import org.eclipse.yasson.internal.adapter.AdapterBinding;
 import org.eclipse.yasson.internal.adapter.DeserializerBinding;
@@ -39,8 +39,6 @@ public abstract class Customization {
 
     private final JsonbDateFormatter dateTimeFormatter;
 
-    private final JsonbNumberFormatter numberFormat;
-
     /**
      * Copies properties from builder an creates immutable instance.
      *
@@ -50,7 +48,6 @@ public abstract class Customization {
         this.nillable = builder.isNillable();
         this.jsonbTransient = builder.isJsonbTransient();
         this.dateTimeFormatter = builder.getDateFormatter();
-        this.numberFormat = builder.getNumberFormat();
         this.adapterBinding = builder.getAdapterInfo();
         this.serializerBinding = builder.getSerializerBinding();
         this.deserializerBinding = builder.getDeserializerBinding();
@@ -65,7 +62,6 @@ public abstract class Customization {
         this.nillable = other.isNillable();
         this.jsonbTransient = other.isJsonbTransient();
         this.dateTimeFormatter = other.getDateTimeFormatter();
-        this.numberFormat = other.getNumberFormat();
         this.adapterBinding = other.getAdapterBinding();
         this.serializerBinding = other.getSerializerBinding();
         this.deserializerBinding = other.getDeserializerBinding();
@@ -101,16 +97,6 @@ public abstract class Customization {
     }
 
     /**
-     * Number format for formatting numbers.
-     *
-     * @return number format
-     */
-    public JsonbNumberFormatter getNumberFormat() {
-        return numberFormat;
-    }
-
-
-    /**
      * Adapter wrapper class with resolved generic information.
      *
      * @return adapter wrapper
@@ -136,4 +122,21 @@ public abstract class Customization {
     public DeserializerBinding getDeserializerBinding() {
         return deserializerBinding;
     }
+
+    /**
+     * Number formatter for formatting numbers during serialization process. It could be the same formatter instance used for deserialization
+     * (returned by {@link #getDeserializeNumberFormatter()}
+     *
+     * @return number formatter
+     */
+    public abstract JsonbNumberFormatter getSerializeNumberFormatter();
+
+    /**
+     * Number formatter for formatting numbers during deserialization process. It could be the same formatter instance used for serialization
+     * (returned by {@link #getSerializeNumberFormatter()}
+     *
+     * @return number formatter
+     */
+    public abstract JsonbNumberFormatter getDeserializeNumberFormatter();
+
 }

--- a/src/main/java/org/eclipse/yasson/model/customization/CustomizationBuilder.java
+++ b/src/main/java/org/eclipse/yasson/model/customization/CustomizationBuilder.java
@@ -11,28 +11,24 @@
  * Roman Grigoriadi
  ******************************************************************************/
 
-package org.eclipse.yasson.model;
+package org.eclipse.yasson.model.customization;
 
 import org.eclipse.yasson.internal.adapter.AdapterBinding;
 import org.eclipse.yasson.internal.adapter.DeserializerBinding;
 import org.eclipse.yasson.internal.adapter.SerializerBinding;
 import org.eclipse.yasson.internal.serializer.JsonbDateFormatter;
-import org.eclipse.yasson.internal.serializer.JsonbNumberFormatter;
+import org.eclipse.yasson.model.JsonbCreator;
 
 /**
- * Builder for ensuring immutable state of {@link Customization} objects.
+ * Abstract base builder for ensuring immutable state of {@link Customization} objects.
  *
  * @author Roman Grigoriadi
  */
-public class CustomizationBuilder {
+public abstract class CustomizationBuilder {
 
     private boolean nillable;
 
     private boolean jsonbTransient;
-
-    private String jsonReadName;
-
-    private String jsonWriteName;
 
     private AdapterBinding adapterInfo;
 
@@ -42,29 +38,9 @@ public class CustomizationBuilder {
 
     private JsonbDateFormatter dateFormatter;
 
-    private JsonbNumberFormatter numberFormat;
-
     private JsonbCreator creator;
 
     private String[] propertyOrder;
-
-    /**
-     * Creates a customization for class properties.
-     *
-     * @return A new instance of {@link PropertyCustomization}
-     */
-    public PropertyCustomization buildPropertyCustomization() {
-        return new PropertyCustomization(this);
-    }
-
-    /**
-     * Creates customization for class.
-     *
-     * @return A new instance of {@link ClassCustomization}
-     */
-    public ClassCustomization buildClassCustomization() {
-        return new ClassCustomization(this);
-    }
 
     /**
      * Returns true if <i>nillable</i> customization is present.
@@ -100,42 +76,6 @@ public class CustomizationBuilder {
      */
     public void setJsonbTransient(boolean jsonbTransient) {
         this.jsonbTransient = jsonbTransient;
-    }
-
-    /**
-     * Sets a JSON property name used to read a property value from on deserialization.
-     *
-     * @return JSON property name
-     */
-    public String getJsonReadName() {
-        return jsonReadName;
-    }
-
-    /**
-     * Sets a JSON property name used to read a property value from on deserialization.
-     *
-     * @param jsonReadName JSON property name
-     */
-    public void setJsonReadName(String jsonReadName) {
-        this.jsonReadName = jsonReadName;
-    }
-
-    /**
-     * Gets a property name which is written to JSON document on serialization.
-     *
-     * @return Property name.
-     */
-    public String getJsonWriteName() {
-        return jsonWriteName;
-    }
-
-    /**
-     * Sets a property name which is written to JSON document on serialization.
-     *
-     * @param jsonWriteName Property name.
-     */
-    public void setJsonWriteName(String jsonWriteName) {
-        this.jsonWriteName = jsonWriteName;
     }
 
     /**
@@ -208,24 +148,6 @@ public class CustomizationBuilder {
      */
     public void setDateFormatter(JsonbDateFormatter dateFormatter) {
         this.dateFormatter = dateFormatter;
-    }
-
-    /**
-     * Gets number formatter for formatting numbers.
-     *
-     * @return Number format.
-     */
-    public JsonbNumberFormatter getNumberFormat() {
-        return numberFormat;
-    }
-
-    /**
-     * Sets number formatter for formatting numbers.
-     *
-     * @param numberFormat Number format.
-     */
-    public void setNumberFormat(JsonbNumberFormatter numberFormat) {
-        this.numberFormat = numberFormat;
     }
 
     /**

--- a/src/main/java/org/eclipse/yasson/model/customization/PropertyCustomization.java
+++ b/src/main/java/org/eclipse/yasson/model/customization/PropertyCustomization.java
@@ -11,7 +11,9 @@
  * Roman Grigoriadi
  ******************************************************************************/
 
-package org.eclipse.yasson.model;
+package org.eclipse.yasson.model.customization;
+
+import org.eclipse.yasson.internal.serializer.JsonbNumberFormatter;
 
 /**
  * Customization for a property of a class.
@@ -24,15 +26,21 @@ public class PropertyCustomization extends Customization {
 
     private final String jsonWriteName;
 
+    private final JsonbNumberFormatter serializeNumberFormatter;
+
+    private final JsonbNumberFormatter deserializeNumberFormatter;
+
 
     /**
      * Copies properties from builder an creates immutable instance.
      * @param builder not null
      */
-    public PropertyCustomization(CustomizationBuilder builder) {
+    public PropertyCustomization(PropertyCustomizationBuilder builder) {
         super(builder);
         this.jsonReadName = builder.getJsonReadName();
         this.jsonWriteName = builder.getJsonWriteName();
+        this.serializeNumberFormatter = builder.getSerializeNumberFormatter();
+        this.deserializeNumberFormatter = builder.getDeserializeNumberFormatter();
     }
 
     /**
@@ -51,4 +59,13 @@ public class PropertyCustomization extends Customization {
         return jsonWriteName;
     }
 
+    @Override
+    public JsonbNumberFormatter getSerializeNumberFormatter() {
+        return serializeNumberFormatter;
+    }
+
+    @Override
+    public JsonbNumberFormatter getDeserializeNumberFormatter() {
+        return deserializeNumberFormatter;
+    }
 }

--- a/src/main/java/org/eclipse/yasson/model/customization/PropertyCustomizationBuilder.java
+++ b/src/main/java/org/eclipse/yasson/model/customization/PropertyCustomizationBuilder.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2017 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *      Ehsan Zaery Moghaddam (zaerymoghaddam@gmail.com)
+ ******************************************************************************/
+
+package org.eclipse.yasson.model.customization;
+
+import org.eclipse.yasson.internal.serializer.JsonbNumberFormatter;
+
+/**
+ * The property customization builder that would be used to build an instance of {@link PropertyCustomization} to ensure its immutability.
+ *
+ * @author Ehsan Zaery Moghaddam (zaerymoghaddam@gmail.com)
+ */
+public class PropertyCustomizationBuilder extends CustomizationBuilder {
+
+    private String jsonReadName;
+
+    private String jsonWriteName;
+
+    private JsonbNumberFormatter serializeNumberFormatter;
+
+    private JsonbNumberFormatter deserializeNumberFormatter;
+
+    /**
+     * Creates a customization for class properties.
+     *
+     * @return A new instance of {@link PropertyCustomization}
+     */
+    public PropertyCustomization buildPropertyCustomization() {
+        return new PropertyCustomization(this);
+    }
+
+    /**
+     * Gets number formatter for formatting numbers during serialization process.
+     *
+     * @return Number formatter for formatting numbers during serialization process.
+     */
+    public JsonbNumberFormatter getSerializeNumberFormatter() {
+        return serializeNumberFormatter;
+    }
+
+    /**
+     * Sets number formatter for formatting numbers during serialization process.
+     *
+     * @param serializeNumberFormatter Number formatter for formatting numbers during serialization process.
+     */
+    public void setSerializeNumberFormatter(JsonbNumberFormatter serializeNumberFormatter) {
+        this.serializeNumberFormatter = serializeNumberFormatter;
+    }
+
+    /**
+     * Gets number formatter for formatting numbers during deserialization process.
+     *
+     * @return Number formatter for formatting numbers during deserialization process.
+     */
+    public JsonbNumberFormatter getDeserializeNumberFormatter() {
+        return deserializeNumberFormatter;
+    }
+
+    /**
+     * Sets number formatter for formatting numbers during deserialization process.
+     *
+     * @param deserializeNumberFormatter Number formatter for formatting numbers during deserialization process.
+     */
+    public void setDeserializeNumberFormatter(JsonbNumberFormatter deserializeNumberFormatter) {
+        this.deserializeNumberFormatter = deserializeNumberFormatter;
+    }
+
+    /**
+     * Sets a JSON property name used to read a property value from on deserialization.
+     *
+     * @return JSON property name
+     */
+    public String getJsonReadName() {
+        return jsonReadName;
+    }
+
+    /**
+     * Sets a JSON property name used to read a property value from on deserialization.
+     *
+     * @param jsonReadName JSON property name
+     */
+    public void setJsonReadName(String jsonReadName) {
+        this.jsonReadName = jsonReadName;
+    }
+
+    /**
+     * Gets a property name which is written to JSON document on serialization.
+     *
+     * @return Property name.
+     */
+    public String getJsonWriteName() {
+        return jsonWriteName;
+    }
+
+    /**
+     * Sets a property name which is written to JSON document on serialization.
+     *
+     * @param jsonWriteName Property name.
+     */
+    public void setJsonWriteName(String jsonWriteName) {
+        this.jsonWriteName = jsonWriteName;
+    }
+
+}

--- a/src/test/java/org/eclipse/yasson/customization/NumberFormatTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/NumberFormatTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.yasson.customization;
 
 import org.eclipse.yasson.customization.model.NumberFormatPojo;
+import org.eclipse.yasson.customization.model.NumberFormatPojoWithoutClassLevelFormatter;
 import org.junit.Test;
 
 import javax.json.bind.Jsonb;
@@ -30,8 +31,6 @@ import static org.junit.Assert.assertEquals;
 public class NumberFormatTest {
     private Jsonb jsonb = JsonbBuilder.create();
 
-
-
     @Test
     public void testSerialize() {
         NumberFormatPojo pojo = new NumberFormatPojo();
@@ -47,15 +46,14 @@ public class NumberFormatTest {
         pojo.setDoubleSetterFormatted(.5d);
         pojo.setDoubleSetterAndPropertyFormatter(0.6d);
 
-        String expectedJson = "{\"aByte\":\"127\",\"aDouble\":\"000.10000000\",\"aFloat\":\"000.34999999\",\"aLong\":\"9223372036854775807\",\"aShort\":\"00001\",\"bigDecimal\":\"00000010.000000\",\"bigInteger\":\"00000001\",\"doubleGetterFormatted\":\"000.10000000\",\"doubleSetterAndPropertyFormatter\":\"000.600\",\"doubleSetterFormatted\":0.5,\"integer\":\"2147483647.0\"}";
+        String expectedJson = "{\"aByte\":\"127\",\"aDouble\":\"000.10000000\",\"aFloat\":\"000.34999999\",\"aLong\":\"9223372036854775807\",\"aShort\":\"00001\",\"bigDecimal\":\"00000010.000000\",\"bigInteger\":\"00000001\",\"doubleGetterFormatted\":\"000.10000000\",\"doubleSetterAndPropertyFormatter\":\"000.600\",\"doubleSetterFormatted\":\"0.5\",\"integer\":\"2147483647.0\"}";
 
         assertEquals(expectedJson, jsonb.toJson(pojo));
-
     }
 
     @Test
     public void testDeserializer() {
-        String expectedJson = "{\"aByte\":\"127\",\"aDouble\":\"000.10000000\",\"aFloat\":\"000.34999999\",\"aLong\":\"9223372036854775807\",\"aShort\":\"00001\",\"bigDecimal\":\"00000010.000000\",\"bigInteger\":\"00000001\",\"doubleGetterFormatted\":\"000.10000\",\"doubleSetterFormatted\":\",005\",\"doubleSetterAndPropertyFormatter\":\"000.600\",\"integer\":\"2147483647.0\"}";
+        String expectedJson = "{\"aByte\":\"127\",\"aDouble\":\"000.10000000\",\"aFloat\":\"000.34999999\",\"aLong\":\"9223372036854775807\",\"aShort\":\"00001\",\"bigDecimal\":\"00000010.000000\",\"bigInteger\":\"00000001\",\"doubleGetterFormatted\":\"000.10000\",\"doubleSetterFormatted\":\",005\",\"doubleSetterAndPropertyFormatter\":\"000,600\",\"integer\":\"2147483647.0\"}";
         NumberFormatPojo pojo = jsonb.fromJson(expectedJson, NumberFormatPojo.class);
 
         assertEquals(BigDecimal.TEN, pojo.bigDecimal);
@@ -71,4 +69,25 @@ public class NumberFormatTest {
         assertEquals(new Double(.6d), pojo.getDoubleSetterAndPropertyFormatter());
     }
 
+    @Test
+    public void testSerializeWithoutClassLevelFormatter() {
+        NumberFormatPojoWithoutClassLevelFormatter pojo = new NumberFormatPojoWithoutClassLevelFormatter();
+        pojo.setDoubleGetterFormatted(.1d);
+        pojo.setDoubleSetterFormatted(.5d);
+        pojo.setDoubleSetterAndPropertyFormatter(0.6d);
+
+        String expectedJson = "{\"doubleGetterFormatted\":\"000.10000000\",\"doubleSetterAndPropertyFormatter\":\"000.600\",\"doubleSetterFormatted\":0.5}";
+
+        assertEquals(expectedJson, jsonb.toJson(pojo));
+    }
+
+    @Test
+    public void testDeserializeWithoutClassLevelFormatter() {
+        String expectedJson = "{\"doubleGetterFormatted\":\"000.10000\",\"doubleSetterFormatted\":\",005\",\"doubleSetterAndPropertyFormatter\":\"000,600\"}";
+        NumberFormatPojoWithoutClassLevelFormatter pojo = jsonb.fromJson(expectedJson, NumberFormatPojoWithoutClassLevelFormatter.class);
+
+        assertEquals(new Double(.1d), pojo.getDoubleGetterFormatted());
+        assertEquals(new Double(.005d), pojo.getDoubleSetterFormatted());
+        assertEquals(new Double(.6d), pojo.getDoubleSetterAndPropertyFormatter());
+    }
 }

--- a/src/test/java/org/eclipse/yasson/customization/NumberFormatTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/NumberFormatTest.java
@@ -43,8 +43,11 @@ public class NumberFormatTest {
         pojo.integer = Integer.MAX_VALUE;
         pojo.aShort = 1;
         pojo.aByte = 127;
+        pojo.setDoubleGetterFormatted(.1d);
+        pojo.setDoubleSetterFormatted(.5d);
+        pojo.setDoubleSetterAndPropertyFormatter(0.6d);
 
-        String expectedJson = "{\"aByte\":\"127\",\"aDouble\":\"000.10000000\",\"aFloat\":\"000.34999999\",\"aLong\":\"9223372036854775807\",\"aShort\":\"00001\",\"bigDecimal\":\"00000010.000000\",\"bigInteger\":\"00000001\",\"integer\":\"2147483647.0\"}";
+        String expectedJson = "{\"aByte\":\"127\",\"aDouble\":\"000.10000000\",\"aFloat\":\"000.34999999\",\"aLong\":\"9223372036854775807\",\"aShort\":\"00001\",\"bigDecimal\":\"00000010.000000\",\"bigInteger\":\"00000001\",\"doubleGetterFormatted\":\"000.10000000\",\"doubleSetterAndPropertyFormatter\":\"000.600\",\"doubleSetterFormatted\":0.5,\"integer\":\"2147483647.0\"}";
 
         assertEquals(expectedJson, jsonb.toJson(pojo));
 
@@ -52,7 +55,7 @@ public class NumberFormatTest {
 
     @Test
     public void testDeserializer() {
-        String expectedJson = "{\"aByte\":\"127\",\"aDouble\":\"000.10000000\",\"aFloat\":\"000.34999999\",\"aLong\":\"9223372036854775807\",\"aShort\":\"00001\",\"bigDecimal\":\"00000010.000000\",\"bigInteger\":\"00000001\",\"integer\":\"2147483647.0\"}";
+        String expectedJson = "{\"aByte\":\"127\",\"aDouble\":\"000.10000000\",\"aFloat\":\"000.34999999\",\"aLong\":\"9223372036854775807\",\"aShort\":\"00001\",\"bigDecimal\":\"00000010.000000\",\"bigInteger\":\"00000001\",\"doubleGetterFormatted\":\"000.10000\",\"doubleSetterFormatted\":\",005\",\"doubleSetterAndPropertyFormatter\":\"000.600\",\"integer\":\"2147483647.0\"}";
         NumberFormatPojo pojo = jsonb.fromJson(expectedJson, NumberFormatPojo.class);
 
         assertEquals(BigDecimal.TEN, pojo.bigDecimal);
@@ -63,6 +66,9 @@ public class NumberFormatTest {
         assertEquals((Integer)Integer.MAX_VALUE, pojo.integer);
         assertEquals(new Short((short) 1), pojo.aShort);
         assertEquals((Long)Long.MAX_VALUE, pojo.aLong);
+        assertEquals(new Double(.1d), pojo.getDoubleGetterFormatted());
+        assertEquals(new Double(.005d), pojo.getDoubleSetterFormatted());
+        assertEquals(new Double(.6d), pojo.getDoubleSetterAndPropertyFormatter());
     }
 
 }

--- a/src/test/java/org/eclipse/yasson/customization/model/NumberFormatPojo.java
+++ b/src/test/java/org/eclipse/yasson/customization/model/NumberFormatPojo.java
@@ -45,4 +45,38 @@ public class NumberFormatPojo {
 
     @JsonbNumberFormat("000")
     public Byte aByte;
+
+    private Double doubleGetterFormatted;
+
+    private Double doubleSetterFormatted;
+
+    @JsonbNumberFormat(value = "000.000", locale = "en-us")
+    private Double doubleSetterAndPropertyFormatter;
+
+    @JsonbNumberFormat("000.00000000")
+    public Double getDoubleGetterFormatted() {
+        return doubleGetterFormatted;
+    }
+
+    public void setDoubleGetterFormatted(Double doubleGetterFormatted) {
+        this.doubleGetterFormatted = doubleGetterFormatted;
+    }
+
+    public Double getDoubleSetterFormatted() {
+        return doubleSetterFormatted;
+    }
+
+    @JsonbNumberFormat(value = "000,000", locale = "da-da")
+    public void setDoubleSetterFormatted(Double doubleSetterFormatted) {
+        this.doubleSetterFormatted = doubleSetterFormatted;
+    }
+
+    public Double getDoubleSetterAndPropertyFormatter() {
+        return doubleSetterAndPropertyFormatter;
+    }
+
+    @JsonbNumberFormat(value = "000,000", locale = "da-da")
+    public void setDoubleSetterAndPropertyFormatter(Double doubleSetterAndPropertyFormatter) {
+        this.doubleSetterAndPropertyFormatter = doubleSetterAndPropertyFormatter;
+    }
 }

--- a/src/test/java/org/eclipse/yasson/customization/model/NumberFormatPojoWithoutClassLevelFormatter.java
+++ b/src/test/java/org/eclipse/yasson/customization/model/NumberFormatPojoWithoutClassLevelFormatter.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ * Ehsan Zaery Moghaddam (zaerymoghaddam@gmail.com)
+ ******************************************************************************/
+
+package org.eclipse.yasson.customization.model;
+
+import javax.json.bind.annotation.JsonbNumberFormat;
+
+/**
+ * @author Ehsan Zaery Moghaddam (zaerymoghaddam@gmail.com)
+ */
+public class NumberFormatPojoWithoutClassLevelFormatter {
+    private Double doubleGetterFormatted;
+
+    private Double doubleSetterFormatted;
+
+    @JsonbNumberFormat(value = "000.000", locale = "en-us")
+    private Double doubleSetterAndPropertyFormatter;
+
+    @JsonbNumberFormat("000.00000000")
+    public Double getDoubleGetterFormatted() {
+        return doubleGetterFormatted;
+    }
+
+    public void setDoubleGetterFormatted(Double doubleGetterFormatted) {
+        this.doubleGetterFormatted = doubleGetterFormatted;
+    }
+
+    public Double getDoubleSetterFormatted() {
+        return doubleSetterFormatted;
+    }
+
+    @JsonbNumberFormat(value = "000,000", locale = "da-da")
+    public void setDoubleSetterFormatted(Double doubleSetterFormatted) {
+        this.doubleSetterFormatted = doubleSetterFormatted;
+    }
+
+    public Double getDoubleSetterAndPropertyFormatter() {
+        return doubleSetterAndPropertyFormatter;
+    }
+
+    @JsonbNumberFormat(value = "000,000", locale = "da-da")
+    public void setDoubleSetterAndPropertyFormatter(Double doubleSetterAndPropertyFormatter) {
+        this.doubleSetterAndPropertyFormatter = doubleSetterAndPropertyFormatter;
+    }
+}


### PR DESCRIPTION
I tried to refactor property and class introspection process so that a property can have two separate JsonbNumberFormatter. We can use the same concept for JsonbDateFormatter (issue #10) and after that fix JsonbTransient (issue #9).

Main changes are:

- Change the Customization class to an abstract class and create a two concrete implementation for properties and classes (PropertyCustomization and ClassCustomization) together with their corresponding builder
- Move all customization related classes to a dedicated sub-package
- Define a separate number formatter for serialization and deserialization on Customization class

Let me know if you think this is OK or need any changes. I'll continue on #10 and then #9. You can assign them to me.
  
Signed-off-by: Ehsan Zaery Moghaddam <zaerymoghaddam@gmail.com>