### PR TITLE
Fix date format in collections / maps.

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/JsonbConfigProperties.java
+++ b/src/main/java/org/eclipse/yasson/internal/JsonbConfigProperties.java
@@ -70,11 +70,9 @@ public class JsonbConfigProperties {
 
     private JsonbDateFormatter initDateFormatter(Locale locale) {
         final String dateFormat = getGlobalConfigJsonbDateFormat();
-        //In case of java.time singleton formats will be used inside related (de)serializers,
         if (JsonbDateFormat.DEFAULT_FORMAT.equals(dateFormat) || JsonbDateFormat.TIME_IN_MILLIS.equals(dateFormat)) {
             return new JsonbDateFormatter(dateFormat, locale.toLanguageTag());
         }
-        //if possible create shared instance of java.time formatter.
         return new JsonbDateFormatter(DateTimeFormatter.ofPattern(dateFormat, locale), dateFormat, locale.toLanguageTag());
     }
 

--- a/src/main/java/org/eclipse/yasson/internal/serializer/AbstractDateTimeSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/AbstractDateTimeSerializer.java
@@ -49,7 +49,7 @@ public abstract class AbstractDateTimeSerializer<T> extends AbstractValueTypeSer
     @Override
     public void serialize(T obj, JsonGenerator generator, SerializationContext ctx) {
         final JsonbContext jsonbContext = ((Marshaller) ctx).getJsonbContext();
-        final JsonbDateFormatter formatter = getJsonbDateFormatter();
+        final JsonbDateFormatter formatter = getJsonbDateFormatter(jsonbContext);
         if (model.getContext() == JsonContext.JSON_OBJECT) {
             generator.write(model.getWriteName(), toJson(obj, formatter, jsonbContext));
         } else {
@@ -70,6 +70,11 @@ public abstract class AbstractDateTimeSerializer<T> extends AbstractValueTypeSer
             return String.valueOf(toInstant(object).toEpochMilli());
         } else if (formatter.getDateTimeFormatter() != null) {
             return formatWithFormatter(object, formatter.getDateTimeFormatter());
+        } else {
+            DateTimeFormatter configDateTimeFormatter = jsonbContext.getConfigProperties().getConfigDateFormatter().getDateTimeFormatter();
+            if (configDateTimeFormatter != null) {
+                return formatWithFormatter(object, configDateTimeFormatter);
+            }
         }
         if (jsonbContext.getConfigProperties().isStrictIJson()) {
             return formatStrictIJson(object);
@@ -77,11 +82,11 @@ public abstract class AbstractDateTimeSerializer<T> extends AbstractValueTypeSer
         return formatDefault(object, jsonbContext.getConfigProperties().getLocale(formatter.getLocale()));
     }
 
-    protected JsonbDateFormatter getJsonbDateFormatter() {
+    protected JsonbDateFormatter getJsonbDateFormatter(JsonbContext context) {
         if (model != null && model.getCustomization() != null && model.getCustomization().getSerializeDateFormatter() != null) {
             return model.getCustomization().getSerializeDateFormatter();
         }
-        return JsonbDateFormatter.getDefault();
+        return context.getConfigProperties().getConfigDateFormatter();
     }
 
     /**

--- a/src/test/java/org/eclipse/yasson/defaultmapping/dates/DatesTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/dates/DatesTest.java
@@ -408,4 +408,52 @@ public class DatesTest {
         Assert.assertEquals(LocalDateTime.now().atZone(ZoneId.of("America/Los_Angeles")).getOffset().getTotalSeconds() * 1000,
                 result.getValue().getOffset(System.currentTimeMillis()));
     }
+
+    @Test
+    public void testDateInMap() {
+
+        JsonbConfig config = new JsonbConfig()
+                .withDateFormat("yyyy", Locale.ENGLISH);
+
+        Jsonb jsonb = JsonbBuilder.create(config);
+        LocalDate localDate = LocalDate.of(2017, 9, 14);
+
+        DateInMapPojo pojo = new DateInMapPojo();
+        pojo.setLocalDate(localDate);
+        pojo.setDateMap(new HashMap<>());
+        pojo.getDateMap().put("first", localDate);
+
+        String json = jsonb.toJson(pojo);
+
+        Assert.assertEquals("{\"dateMap\":{\"first\":\"2017\"},\"localDate\":\"2017\"}", json);
+
+        config = new JsonbConfig()
+                .withDateFormat("dd.MM.yyyy", Locale.ENGLISH);
+        jsonb = JsonbBuilder.create(config);
+        DateInMapPojo result = jsonb.fromJson("{\"dateMap\":{\"first\":\"01.01.2017\"},\"localDate\":\"01.01.2017\"}", DateInMapPojo.class);
+        Assert.assertEquals(LocalDate.of(2017,1,1), result.localDate);
+        Assert.assertEquals(LocalDate.of(2017,1,1), result.dateMap.get("first"));
+    }
+
+
+    public static class DateInMapPojo {
+        private LocalDate localDate;
+        private Map<String, LocalDate> dateMap;
+
+        public LocalDate getLocalDate() {
+            return localDate;
+        }
+
+        public void setLocalDate(LocalDate localDate) {
+            this.localDate = localDate;
+        }
+
+        public Map<String, LocalDate> getDateMap() {
+            return dateMap;
+        }
+
+        public void setDateMap(Map<String, LocalDate> dateMap) {
+            this.dateMap = dateMap;
+        }
+    }
 }


### PR DESCRIPTION
Fixes #42 
When date format is declared on JsonbConfig, it is not applied to dates in collections / maps.

Signed-off-by: Roman Grigoriadi <roman.grigoriadi@oracle.com>