### PR TITLE
enum processing fixes

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/serializer/DefaultSerializers.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/DefaultSerializers.java
@@ -109,7 +109,7 @@ public class DefaultSerializers {
     }
 
     private <T> Optional<SerializerProviderWrapper> findByCondition(Class<T> clazz) {
-        if (clazz.isEnum()) {
+        if (Enum.class.isAssignableFrom(clazz)) {
             return Optional.of(enumProvider);
         } else if (JsonString.class.isAssignableFrom(clazz)) {
             return Optional.of(serializers.get(JsonString.class));

--- a/src/main/java/org/eclipse/yasson/internal/serializer/EnumTypeDeserializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/EnumTypeDeserializer.java
@@ -35,13 +35,8 @@ public class EnumTypeDeserializer extends AbstractValueTypeDeserializer<Enum> {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     protected Enum deserialize(String jsonValue, Unmarshaller unmarshaller, Type rtType) {
-        Class<? extends Enum> en = (Class<? extends Enum>) rtType;
-        for (Enum c : en.getEnumConstants()) {
-            if (c.name().equals(jsonValue)) {
-                return c;
-            }
-        }
-        return null;
+        return Enum.valueOf((Class<Enum>) rtType, jsonValue);
     }
 }

--- a/src/main/java/org/eclipse/yasson/internal/serializer/EnumTypeSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/EnumTypeSerializer.java
@@ -36,11 +36,11 @@ public class EnumTypeSerializer extends AbstractValueTypeSerializer<Enum> {
 
     @Override
     protected void serialize(Enum obj, JsonGenerator generator, String key, Marshaller marshaller) {
-        generator.write(key, obj.toString());
+        generator.write(key, obj.name());
     }
 
     @Override
     protected void serialize(Enum obj, JsonGenerator generator, Marshaller marshaller) {
-        generator.write(obj.toString());
+        generator.write(obj.name());
     }
 }

--- a/src/main/java/org/eclipse/yasson/internal/serializer/ObjectDeserializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/ObjectDeserializer.java
@@ -22,6 +22,7 @@ import org.eclipse.yasson.internal.model.PropertyModel;
 import javax.json.bind.JsonbException;
 import javax.json.bind.serializer.JsonbDeserializer;
 import javax.json.stream.JsonParser;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -160,7 +161,8 @@ class ObjectDeserializer<T> extends AbstractContainerDeserializer<T> {
             final JsonbDeserializer<?> deserializer = newUnmarshallerItemBuilder(context.getJsonbContext()).
                     withModel(newPropertyModel).build();
 
-            Object result = deserializer.deserialize(parser, context, newPropertyModel.getPropertyType());
+            Type resolvedType = ReflectionUtils.resolveType(this, newPropertyModel.getPropertyType());
+            Object result = deserializer.deserialize(parser, context, resolvedType);
             values.put(newPropertyModel.getPropertyName(), new ValueWrapper(newPropertyModel, result));
             return;
         }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/EnumTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/EnumTest.java
@@ -1,0 +1,56 @@
+package org.eclipse.yasson.defaultmapping;
+
+import org.eclipse.yasson.TestTypeToken;
+import org.eclipse.yasson.defaultmapping.collections.Language;
+import org.eclipse.yasson.defaultmapping.generics.model.ScalarValueWrapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
+
+import static org.junit.Assert.assertEquals;
+
+public class EnumTest {
+
+    private final Jsonb jsonb = JsonbBuilder.create();
+
+    @Test
+    public void testEnumValue() {
+        assertEquals("\"Russian\"", jsonb.toJson(Language.Russian));
+        Language result = jsonb.fromJson("\"Russian\"", Language.class);
+        Assert.assertEquals(Language.Russian, result);
+    }
+
+    @Test
+    public void testEnumInObject() {
+        Assert.assertEquals("{\"value\":\"Russian\"}", jsonb.toJson(new ScalarValueWrapper<>(Language.Russian)));
+        ScalarValueWrapper<Language> result = jsonb.fromJson("{\"value\":\"Russian\"}", new TestTypeToken<ScalarValueWrapper<Language>>() {
+        }.getType());
+
+        Assert.assertEquals(result.getValue(), Language.Russian);
+    }
+
+    @Test
+    public void testEnumValueWithToStringOverriden() {
+        assertEquals("\"HARD_BACK\"", jsonb.toJson(Binding.HARD_BACK));
+        Binding result = jsonb.fromJson("\"HARD_BACK\"", Binding.class);
+        Assert.assertEquals(Binding.HARD_BACK, result);
+    }
+
+
+    @Test
+    public void testEnumInObjectWithToStringOverriden() {
+        assertEquals("{\"value\":\"HARD_BACK\"}", jsonb.toJson(new ScalarValueWrapper<>(Binding.HARD_BACK)));
+        ScalarValueWrapper<Binding> result = jsonb.fromJson("{\"value\":\"HARD_BACK\"}", new TestTypeToken<ScalarValueWrapper<Binding>>(){}.getType());
+        Assert.assertEquals(Binding.HARD_BACK, result.getValue());
+    }
+
+    public enum Binding {
+        HARD_BACK {
+            public String toString() {
+                return "Hard Back";
+            }
+        }
+    }
+}

--- a/src/test/java/org/eclipse/yasson/defaultmapping/collections/CollectionsTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/collections/CollectionsTest.java
@@ -181,13 +181,6 @@ public class CollectionsTest {
     }
 
     @Test
-    public void testMarshallEnum() {
-
-        final Language language = Language.Russian;
-        assertEquals("{\"value\":\"Russian\"}", jsonb.toJson(new ScalarValueWrapper<>(language)));
-    }
-
-    @Test
     public void testMarshallEnumSet() {
 
         final EnumSet<Language> languageEnumSet = EnumSet.of(Language.Czech, Language.Slovak);


### PR DESCRIPTION
Fixes #48, fixes #47

Serializers and deserializers for anonymous enum value classes are now properly resolved.
Serializer is now using value.name()
Deserializer is using Enum#valueOf()

Signed-off-by: Roman Grigoriadi <roman.grigoriadi@oracle.com>