### PR TITLE
Refined checking for property name clashes

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/ClassParser.java
+++ b/src/main/java/org/eclipse/yasson/internal/ClassParser.java
@@ -13,6 +13,8 @@
 package org.eclipse.yasson.internal;
 
 import org.eclipse.yasson.internal.model.*;
+import org.eclipse.yasson.internal.properties.MessageKeys;
+import org.eclipse.yasson.internal.properties.Messages;
 
 import javax.json.bind.JsonbException;
 import java.beans.Introspector;
@@ -150,10 +152,13 @@ class ClassParser {
         for (PropertyModel collectedPropertyModel : collectedProperties) {
             for (PropertyModel checkedPropertyModel : checkedProperties) {
 
-                if (checkedPropertyModel.getReadName().equals(collectedPropertyModel.getReadName()) ||
-                        checkedPropertyModel.getWriteName().equals(collectedPropertyModel.getWriteName())) {
-                    throw new JsonbException(String.format("Property %s clashes with property %s by read or write name in class %s.",
-                            checkedPropertyModel.getPropertyName(), collectedPropertyModel.getPropertyName(), cls.getName()));
+                if ((checkedPropertyModel.getReadName().equals(collectedPropertyModel.getReadName())
+                && checkedPropertyModel.isReadable() && collectedPropertyModel.isReadable()) ||
+                        (checkedPropertyModel.getWriteName().equals(collectedPropertyModel.getWriteName()))
+                        && checkedPropertyModel.isWritable() && collectedPropertyModel.isWritable()) {
+                    throw new JsonbException(Messages.getMessage(MessageKeys.PROPERTY_NAME_CLASH,
+                            checkedPropertyModel.getPropertyName(), collectedPropertyModel.getPropertyName(),
+                            cls.getName()));
                 }
             }
             checkedProperties.add(collectedPropertyModel);

--- a/src/main/java/org/eclipse/yasson/internal/model/ClassModel.java
+++ b/src/main/java/org/eclipse/yasson/internal/model/ClassModel.java
@@ -86,7 +86,7 @@ public class ClassModel {
     private PropertyModel searchProperty(ClassModel classModel, String jsonReadName) {
         //Standard javabean properties without overridden name (most of the cases)
         final PropertyModel result = classModel.getPropertyModel(jsonReadName);
-        if (result != null && result.getPropertyName().equals(result.getCustomization().getJsonReadName())) {
+        if (result != null && result.getPropertyName().equals(result.getReadName())) {
             return result;
         }
         //Search for overridden name on setter with @JsonbProperty annotation

--- a/src/main/java/org/eclipse/yasson/internal/properties/MessageKeys.java
+++ b/src/main/java/org/eclipse/yasson/internal/properties/MessageKeys.java
@@ -75,6 +75,7 @@ public enum MessageKeys {
     ZONE_PARSE_ERROR("zoneParseError"),
     JSONB_TRANSIENT_WITH_OTHER_ANNOTATIONS("jsonbTransientWithOtherAnnotations"),
     NON_PARAMETRIZED_TYPE("nonParametrizedType"),
+    PROPERTY_NAME_CLASH("propertyNameClash"),
     ;
 
     /** Message bundle key. */

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -69,3 +69,4 @@ jsonbCreatorMissingProperty=JsonbCreator parameter {0} is missing in json docume
 zoneParseError=Can't parse zone from json value: {0}
 jsonbTransientWithOtherAnnotations=JsonbTransient annotation cannot be used with other jsonb annotations on the same property.
 nonParametrizedType=Type: {0} is not a parametrized type.
+propertyNameClash=Property {0} clashes with property {1} by read or write name in class {2}.

--- a/src/test/java/org/eclipse/yasson/customization/JsonbPropertyTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/JsonbPropertyTest.java
@@ -16,11 +16,16 @@ package org.eclipse.yasson.customization;
 import org.eclipse.yasson.customization.model.JsonbPropertyName;
 import org.eclipse.yasson.customization.model.JsonbPropertyNameCollision;
 import org.eclipse.yasson.customization.model.JsonbPropertyNillable;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
+import javax.json.bind.JsonbConfig;
+import javax.json.bind.JsonbException;
+import javax.json.bind.annotation.JsonbProperty;
+import javax.json.bind.config.PropertyNamingStrategy;
 
 import static org.junit.Assert.*;
 
@@ -79,5 +84,112 @@ public class JsonbPropertyTest {
         JsonbPropertyNillable pojo = new JsonbPropertyNillable();
         assertEquals("{\"nullField\":null}", jsonb.toJson(pojo));
     }
+
+    /**
+     * In this test getter / setter doesn't match to field "doi", because declared by javabean convention.
+     * When model is parsed there are to properties:
+     * Property for private field "doi", without customization. This property is not readable because field
+     * is private without getter / setter.
+     * And property "DOI" - getter / setter without a field with customization on getter renaming it to doi
+     * in serialized document.
+     *
+     * Because first of those properties is not readable this should not raise naming clash error.
+     */
+    @Test
+    public void testNonConflictingProperties() {
+        NonConflictingProperties nonConflictingProperties = new NonConflictingProperties();
+        nonConflictingProperties.setDOI("DOI value");
+
+        String json = jsonb.toJson(nonConflictingProperties);
+        Assert.assertEquals("{\"doi\":\"DOI value\"}", json);
+
+        NonConflictingProperties result = jsonb.fromJson("{\"DOI\":\"DOI value\"}", NonConflictingProperties.class);
+        Assert.assertEquals("DOI value", result.getDOI());
+    }
+
+    /**
+     * Same problem as above but now field is public, so clash takes place.
+     */
+    @Test
+    public void testConflictingProperties() {
+        ConflictingProperties conflictingProperties = new ConflictingProperties();
+        conflictingProperties.setDOI("DOI value");
+        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig()
+        );
+
+        try {
+            jsonb.toJson(conflictingProperties);
+            fail();
+        } catch (JsonbException e) {
+            if (!e.getMessage().equals("Property DOI clashes with property doi by read or write name in class org.eclipse.yasson.customization.JsonbPropertyTest$ConflictingProperties.")) {
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * Tests clash with property altered by naming strategy.
+     */
+    @Test
+    public void testConflictingWithUpperCamelStrategy() {
+        ConflictingWithUpperCamelStrategy pojo = new ConflictingWithUpperCamelStrategy();
+        pojo.setDOI("DOI value");
+
+        Jsonb jsonb = JsonbBuilder.create();
+        String json = jsonb.toJson(pojo);
+        Assert.assertEquals("{\"Doi\":\"DOI value\",\"doi\":\"DOI value\"}", json);
+
+        jsonb = JsonbBuilder.create(new JsonbConfig()
+                .withPropertyNamingStrategy(PropertyNamingStrategy.UPPER_CAMEL_CASE));
+
+        try {
+            jsonb.toJson(pojo);
+            fail();
+        } catch (JsonbException e) {
+            if (!e.getMessage().equals("Property DOI clashes with property doi by read or write name in class org.eclipse.yasson.customization.JsonbPropertyTest$ConflictingWithUpperCamelStrategy.")) {
+                throw e;
+            }
+        }
+
+    }
+
+    public static class NonConflictingProperties {
+        private String doi;
+
+        @JsonbProperty("doi")
+        public String getDOI() {
+            return doi;
+        }
+        public void setDOI(String doi) {
+            this.doi = doi;
+        }
+    }
+
+    public static class ConflictingProperties {
+        public String doi;
+
+        @JsonbProperty("doi")
+        public String getDOI() {
+            return doi;
+        }
+        public void setDOI(String doi) {
+            this.doi = doi;
+        }
+    }
+
+
+
+    public static class ConflictingWithUpperCamelStrategy {
+        public String doi;
+
+        @JsonbProperty("Doi")
+        public String getDOI() {
+            return doi;
+        }
+        public void setDOI(String doi) {
+            this.doi = doi;
+        }
+    }
+
 
 }


### PR DESCRIPTION
Property name clash exceptions are now not thrown for name clashes when one of the properties is not readable / writable.

Signed-off-by: Roman Grigoriadi <roman.grigoriadi@oracle.com>