### PR TITLE
PrivateFieldVisibilityStrategy implemented and integrated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <javax.json.version>1.1</javax.json.version>
         <javax.json.bind.version>1.0</javax.json.bind.version>
-        <netbeans.hint.jdkPlatform>JDK_9</netbeans.hint.jdkPlatform>
+        <netbeans.hint.jdkPlatform>@@DEFAU:T@@</netbeans.hint.jdkPlatform>
     </properties>
 
     <profiles>

--- a/src/main/java/org/eclipse/yasson/internal/JsonbConfigProperties.java
+++ b/src/main/java/org/eclipse/yasson/internal/JsonbConfigProperties.java
@@ -1,16 +1,8 @@
 package org.eclipse.yasson.internal;
 
-import org.eclipse.yasson.internal.model.customization.ordering.AnyOrderStrategy;
-import org.eclipse.yasson.internal.model.customization.ordering.LexicographicalOrderStrategy;
-import org.eclipse.yasson.internal.model.customization.ordering.PropOrderStrategy;
-import org.eclipse.yasson.internal.model.customization.ordering.PropertyOrdering;
-import org.eclipse.yasson.internal.model.customization.ordering.ReverseOrderStrategy;
-import org.eclipse.yasson.internal.model.customization.naming.DefaultNamingStrategies;
-import org.eclipse.yasson.internal.model.customization.naming.IdentityStrategy;
-import org.eclipse.yasson.internal.properties.MessageKeys;
-import org.eclipse.yasson.internal.properties.Messages;
-import org.eclipse.yasson.internal.serializer.JsonbDateFormatter;
-
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.Optional;
 import javax.json.bind.JsonbConfig;
 import javax.json.bind.JsonbException;
 import javax.json.bind.annotation.JsonbDateFormat;
@@ -18,9 +10,17 @@ import javax.json.bind.config.BinaryDataStrategy;
 import javax.json.bind.config.PropertyNamingStrategy;
 import javax.json.bind.config.PropertyOrderStrategy;
 import javax.json.bind.config.PropertyVisibilityStrategy;
-import java.time.format.DateTimeFormatter;
-import java.util.Locale;
-import java.util.Optional;
+import org.eclipse.yasson.internal.model.customization.naming.DefaultNamingStrategies;
+import org.eclipse.yasson.internal.model.customization.naming.IdentityStrategy;
+import org.eclipse.yasson.internal.model.customization.ordering.AnyOrderStrategy;
+import org.eclipse.yasson.internal.model.customization.ordering.LexicographicalOrderStrategy;
+import org.eclipse.yasson.internal.model.customization.ordering.PropOrderStrategy;
+import org.eclipse.yasson.internal.model.customization.ordering.PropertyOrdering;
+import org.eclipse.yasson.internal.model.customization.ordering.ReverseOrderStrategy;
+import org.eclipse.yasson.internal.model.customization.visibility.PrivateFieldVisibilityStrategy;
+import org.eclipse.yasson.internal.properties.MessageKeys;
+import org.eclipse.yasson.internal.properties.Messages;
+import org.eclipse.yasson.internal.serializer.JsonbDateFormatter;
 
 /**
  * Resolved properties from JSONB config.
@@ -131,7 +131,9 @@ public class JsonbConfigProperties {
     private PropertyVisibilityStrategy initPropertyVisibilityStrategy() {
         final Optional<Object> property = jsonbConfig.getProperty(JsonbConfig.PROPERTY_VISIBILITY_STRATEGY);
         if (!property.isPresent()) {
-            return null;
+            PrivateFieldVisibilityStrategy privateVisibilityStrategy = new PrivateFieldVisibilityStrategy();
+            jsonbConfig.setProperty(JsonbConfig.PROPERTY_VISIBILITY_STRATEGY, privateVisibilityStrategy);
+            return privateVisibilityStrategy;
         }
         final Object propertyVisibilityStrategy = property.get();
         if (!(propertyVisibilityStrategy instanceof PropertyVisibilityStrategy)) {

--- a/src/main/java/org/eclipse/yasson/internal/model/customization/visibility/PrivateFieldVisibilityStrategy.java
+++ b/src/main/java/org/eclipse/yasson/internal/model/customization/visibility/PrivateFieldVisibilityStrategy.java
@@ -7,7 +7,7 @@ import javax.json.bind.config.PropertyVisibilityStrategy;
 
 /**
  *
- * @author adam-bien.com
+ * @author Adam Bien
  */
 public class PrivateFieldVisibilityStrategy implements PropertyVisibilityStrategy {
 

--- a/src/main/java/org/eclipse/yasson/internal/model/customization/visibility/PrivateFieldVisibilityStrategy.java
+++ b/src/main/java/org/eclipse/yasson/internal/model/customization/visibility/PrivateFieldVisibilityStrategy.java
@@ -1,0 +1,24 @@
+
+package org.eclipse.yasson.internal.model.customization.visibility;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import javax.json.bind.config.PropertyVisibilityStrategy;
+
+/**
+ *
+ * @author adam-bien.com
+ */
+public class PrivateFieldVisibilityStrategy implements PropertyVisibilityStrategy {
+
+    @Override
+    public boolean isVisible(Field field) {
+        return true;
+    }
+
+    @Override
+    public boolean isVisible(Method method) {
+        return false;
+    }
+
+}

--- a/src/test/java/org/eclipse/yasson/internal/model/customization/visibility/Message.java
+++ b/src/test/java/org/eclipse/yasson/internal/model/customization/visibility/Message.java
@@ -1,0 +1,16 @@
+
+package org.eclipse.yasson.internal.model.customization.visibility;
+
+/**
+ *
+ * @author airhacks.com
+ */
+public class Message {
+
+    private String content;
+
+    public Message(String content) {
+        this.content = content;
+    }
+
+}

--- a/src/test/java/org/eclipse/yasson/internal/model/customization/visibility/Message.java
+++ b/src/test/java/org/eclipse/yasson/internal/model/customization/visibility/Message.java
@@ -3,7 +3,7 @@ package org.eclipse.yasson.internal.model.customization.visibility;
 
 /**
  *
- * @author airhacks.com
+ * @author Adam Bien
  */
 public class Message {
 

--- a/src/test/java/org/eclipse/yasson/internal/model/customization/visibility/PrivateFieldVisibilityStrategyTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/model/customization/visibility/PrivateFieldVisibilityStrategyTest.java
@@ -1,0 +1,23 @@
+/*
+ */
+package org.eclipse.yasson.internal.model.customization.visibility;
+
+import javax.json.bind.JsonbBuilder;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+
+/**
+ *
+ * @author airhacks.com
+ */
+public class PrivateFieldVisibilityStrategyTest {
+
+    @Test
+    public void serializeIntoStringWithoutCustomStrategy() {
+        String serialized = JsonbBuilder.create().
+                toJson(new Message("duke"));
+        System.out.println("retVal = " + serialized);
+        assertThat(serialized, containsString("duke"));
+    }
+}

--- a/src/test/java/org/eclipse/yasson/internal/model/customization/visibility/PrivateFieldVisibilityStrategyTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/model/customization/visibility/PrivateFieldVisibilityStrategyTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 
 /**
  *
- * @author airhacks.com
+ * @author Adam Bien
  */
 public class PrivateFieldVisibilityStrategyTest {
 


### PR DESCRIPTION
This change allows private fields in classes to be serialized per convention without any additional changes. IMO the default behavior should be aligned with JPA. 

VisibilityStrategy should be configurable per project and package level.

However: it breaks the remaining unit tests. I didn't fix them,  because I was not sure whether this pull request gets accepted.