### PR TITLE
Ignore property methods with incorrect number of arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target/
+.classpath
+.project
+.settings/

--- a/src/test/java/org/eclipse/yasson/defaultmapping/basic/UnqualifiedPropertiesTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/basic/UnqualifiedPropertiesTest.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ * Andrew Guibert
+ ******************************************************************************/
+package org.eclipse.yasson.defaultmapping.basic;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.json.bind.JsonbBuilder;
+
+import org.junit.Test;
+
+public class UnqualifiedPropertiesTest {
+	
+	public static class Widget {
+		
+		public long now;
+
+	    public String getFoo() {
+	        return "foo";
+	    }
+
+	    public String getBar(final int baz) {
+	        return "bar" + baz;
+	    }
+	    
+	    public boolean isPositive(int num) {
+	    	return num > 0;
+	    }
+	    
+	    public Widget setNow() {
+	    	now = 1511576115722L;
+	    	return this;
+	    }
+	}
+	
+	@Test
+	public void testGetWithArgs() {
+	    assertEquals("{\"foo\":\"foo\",\"now\":0}", JsonbBuilder.create().toJson(new Widget()));
+	}
+	
+	@Test
+	public void testSetWithNoArgs() {
+		assertEquals("{\"foo\":\"foo\",\"now\":1511576115722}", JsonbBuilder.create().toJson(new Widget().setNow()));
+	}
+	
+}


### PR DESCRIPTION
Previously we assumed that if a method started with "get" or "is" that
it had 0 arguments.  Likewise we assumed that if a method started with
"set" it had exactly 1 argument.  These unchecked assumptions cause
IllegalStateExceptions later on in execution, and impose unnecessary
constraints on method signatures of JSON-B model classes.

Resolves issue #63 