### PR TITLE
Enforce US Locale for the duration of the tests

### DIFF
--- a/src/test/java/org/eclipse/yasson/customization/NumberFormatTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/NumberFormatTest.java
@@ -15,12 +15,15 @@ package org.eclipse.yasson.customization;
 
 import org.eclipse.yasson.customization.model.NumberFormatPojo;
 import org.eclipse.yasson.customization.model.NumberFormatPojoWithoutClassLevelFormatter;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
 
@@ -29,7 +32,20 @@ import static org.junit.Assert.assertEquals;
  * @author Roman Grigoriadi
  */
 public class NumberFormatTest {
-    private Jsonb jsonb = JsonbBuilder.create();
+    private Jsonb jsonb;
+    private Locale systemDefaultLocale;
+
+    @Before
+    public void setUp() {
+        systemDefaultLocale = Locale.getDefault();
+        Locale.setDefault(Locale.US);
+        jsonb = JsonbBuilder.create();
+    }
+
+    @After
+    public void tearDown() {
+        Locale.setDefault(systemDefaultLocale);
+    }
 
     @Test
     public void testSerialize() {

--- a/src/test/java/org/eclipse/yasson/customization/NumberFormatTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/NumberFormatTest.java
@@ -15,7 +15,6 @@ package org.eclipse.yasson.customization;
 
 import org.eclipse.yasson.customization.model.NumberFormatPojo;
 import org.eclipse.yasson.customization.model.NumberFormatPojoWithoutClassLevelFormatter;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -24,6 +23,7 @@ import javax.json.bind.JsonbBuilder;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Locale;
+import javax.json.bind.JsonbConfig;
 
 import static org.junit.Assert.assertEquals;
 
@@ -33,18 +33,10 @@ import static org.junit.Assert.assertEquals;
  */
 public class NumberFormatTest {
     private Jsonb jsonb;
-    private Locale systemDefaultLocale;
 
     @Before
     public void setUp() {
-        systemDefaultLocale = Locale.getDefault();
-        Locale.setDefault(Locale.US);
-        jsonb = JsonbBuilder.create();
-    }
-
-    @After
-    public void tearDown() {
-        Locale.setDefault(systemDefaultLocale);
+        jsonb = JsonbBuilder.create(new JsonbConfig().withLocale(Locale.US));
     }
 
     @Test


### PR DESCRIPTION
The NumberFormatTest relies on the default Locale and depends on where it's running.

For instance, decimals are starting with a comma `,` in France so all decimal printing assertions fails there.

These changes forces the locale to en/US for the duration of the test.