### PR TITLE
Explicitly require Java EE CDI API in module-info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .classpath
 .project
 .settings/
+*.iml
+.idea

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -17,6 +17,8 @@ module org.eclipse.yasson {
     requires java.desktop;
     requires java.logging;
 
+    requires cdi.api;
+
     exports org.eclipse.yasson;
     provides javax.json.bind.spi.JsonbProvider with org.eclipse.yasson.JsonBindingProvider;
 }


### PR DESCRIPTION
When running the library in a Named Module-based application, the CDI
API is explicitly required in order for the library to access the SPI,
otherwise an AccessDenied will be thrown.

This added the cdi.api module to the modules the yasson library reads.

Closes #71