### PR TITLE
Handle Errors while searching for CDI providers

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/components/JsonbComponentInstanceCreatorFactory.java
+++ b/src/main/java/org/eclipse/yasson/internal/components/JsonbComponentInstanceCreatorFactory.java
@@ -46,7 +46,7 @@ public class JsonbComponentInstanceCreatorFactory {
     public static JsonbComponentInstanceCreator getComponentInstanceCreator() {
         try {
             return new BeanManagerInstanceCreator(CDI.current().getBeanManager());
-        } catch (Exception e) {
+        } catch (Throwable e) {
             log.finest(Messages.getMessage(MessageKeys.BEAN_MANAGER_NOT_FOUND_NO_PROVIDER));
             try {
                 InitialContext context = new InitialContext();


### PR DESCRIPTION
I had to make this change to avoid failures like the following where some spurious CDI provider was missing a class dependency:

```
javax.json.bind.JsonbException: Error loading JsonbComponentInstanceCreator

	at org.eclipse.yasson.internal.components.InstanceCreatorFactoryHelper.lambda$getComponentInstanceCreator$0(InstanceCreatorFactoryHelper.java:37)
	at java.security.AccessController.doPrivileged(Native Method)
	at org.eclipse.yasson.internal.components.InstanceCreatorFactoryHelper.getComponentInstanceCreator(InstanceCreatorFactoryHelper.java:28)
	at org.eclipse.yasson.internal.JsonbContext.<init>(JsonbContext.java:71)
	at org.eclipse.yasson.internal.JsonBinding.<init>(JsonBinding.java:41)
	at org.eclipse.yasson.internal.JsonBindingBuilder.build(JsonBindingBuilder.java:63)
	at javax.json.bind.JsonbBuilder.create(JsonbBuilder.java:123)
	at api.TestCryptopia.testBalancesEntity(TestCryptopia.java:90)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:160)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.yasson.internal.components.InstanceCreatorFactoryHelper.lambda$getComponentInstanceCreator$0(InstanceCreatorFactoryHelper.java:33)
	... 29 more
Caused by: java.lang.NoClassDefFoundError: com/google/common/cache/CacheLoader
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:348)
	at javax.enterprise.inject.spi.CDI.findAllProviders(CDI.java:117)
	at javax.enterprise.inject.spi.CDI.current(CDI.java:53)
	at org.eclipse.yasson.internal.components.JsonbComponentInstanceCreatorFactory.getComponentInstanceCreator(JsonbComponentInstanceCreatorFactory.java:48)
	... 34 more
Caused by: java.lang.ClassNotFoundException: com.google.common.cache.CacheLoader
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:335)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 39 more
```
