### PR TITLE
Add default deserializer for UUID

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/serializer/DefaultSerializers.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/DefaultSerializers.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -76,6 +76,7 @@ public class DefaultSerializers {
         serializers.put(TimeZone.class, new SerializerProviderWrapper(TimeZoneTypeSerializer::new, TimeZoneTypeDeserializer::new));
         serializers.put(URI.class, new SerializerProviderWrapper(URITypeSerializer::new, URITypeDeserializer::new));
         serializers.put(URL.class, new SerializerProviderWrapper(URLTypeSerializer::new, URLTypeDeserializer::new));
+        serializers.put(UUID.class, new SerializerProviderWrapper(UUIDTypeSerializer::new, UUIDTypeDeserializer::new));
         serializers.put(ZonedDateTime.class, new SerializerProviderWrapper(ZonedDateTimeTypeSerializer::new, ZonedDateTimeTypeDeserializer::new));
         serializers.put(Duration.class, new SerializerProviderWrapper(DurationTypeSerializer::new, DurationTypeDeserializer::new));
         serializers.put(Period.class, new SerializerProviderWrapper(PeriodTypeSerializer::new, PeriodTypeDeserializer::new));

--- a/src/main/java/org/eclipse/yasson/internal/serializer/UUIDTypeDeserializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/UUIDTypeDeserializer.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ ******************************************************************************/
+
+package org.eclipse.yasson.internal.serializer;
+
+
+import org.eclipse.yasson.internal.Unmarshaller;
+import org.eclipse.yasson.internal.model.JsonBindingModel;
+
+import java.lang.reflect.Type;
+import java.util.UUID;
+
+/**
+ * Deserializer for {@link UUID} type.
+ */
+public class UUIDTypeDeserializer extends AbstractValueTypeDeserializer<UUID> {
+
+    /**
+     * Creates a new instance.
+     *
+     * @param model Binding model.
+     */
+    public UUIDTypeDeserializer(JsonBindingModel model) {
+        super(UUID.class, model);
+    }
+
+    @Override
+    protected UUID deserialize(String jsonValue, Unmarshaller unmarshaller, Type rtType) {
+        return UUID.fromString(jsonValue);
+    }
+}

--- a/src/main/java/org/eclipse/yasson/internal/serializer/UUIDTypeSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/UUIDTypeSerializer.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ ******************************************************************************/
+
+package org.eclipse.yasson.internal.serializer;
+
+
+import org.eclipse.yasson.internal.Marshaller;
+import org.eclipse.yasson.internal.model.JsonBindingModel;
+
+import javax.json.stream.JsonGenerator;
+import java.util.UUID;
+
+/**
+ * Serializer for {@link UUID} type.
+ */
+public class UUIDTypeSerializer extends AbstractValueTypeSerializer<UUID> {
+
+    /**
+     * Creates a new instance.
+     *
+     * @param model Binding model.
+     */
+    public UUIDTypeSerializer(JsonBindingModel model) {
+        super(model);
+    }
+
+    @Override
+    protected void serialize(UUID obj, JsonGenerator generator, Marshaller marshaller) {
+        generator.write(obj.toString());
+    }
+}

--- a/src/test/java/org/eclipse/yasson/defaultmapping/typeConvertors/DefaultSerializersTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/typeConvertors/DefaultSerializersTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -23,6 +23,7 @@ import javax.json.bind.JsonbBuilder;
 import javax.json.bind.JsonbConfig;
 import javax.json.bind.config.BinaryDataStrategy;
 import java.util.Base64;
+import java.util.UUID;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -111,5 +112,14 @@ public class DefaultSerializersTest {
         assertEquals(base64UrlEncodedJson, jsonb.toJson(byteArrayWrapper));
         result = jsonb.fromJson(base64UrlEncodedJson, ByteArrayWrapper.class);
         assertArrayEquals(array, result.array);
+    }
+
+    @Test
+    public void testUUID() {
+        Jsonb jsonb = JsonbBuilder.create();
+        UUID uuid = UUID.randomUUID();
+        String json = jsonb.toJson(uuid);
+        UUID result = jsonb.fromJson(json, UUID.class);
+        assertEquals(uuid, result);
     }
 }


### PR DESCRIPTION
The pull relates to issue #77 
While I didn't run into any issues with using a JsonbDeserializer to unmarshall UUID as the reporter of that issue did, having built-in support for UUID seems useful, so I'm adding it under this pull, along with a test case.